### PR TITLE
fix for local execution

### DIFF
--- a/experiments/exp_driver.py
+++ b/experiments/exp_driver.py
@@ -135,6 +135,7 @@ if __name__ == '__main__':
         VARS["SLURM_CONFIG"] = ""
         VARS["NUM_DEVICES_PER_NODE"] = args.num_nodes #args.num_devices_per_node
         VARS["ONE_NODE_DDP"] = "--one_node_ddp"
+        VARS["NUM_MACHINES"] = 1
     else:
         for x in VARS.keys():
             VARS[x] = str(VARS[x])

--- a/experiments/exp_utils/utils.py
+++ b/experiments/exp_utils/utils.py
@@ -23,7 +23,7 @@ def run_experiment(args, *pos_args, job_list_file, dataset_name, num_nodes, gpu_
         additional_args = additional_args + f"--num_samplers {args.num_samplers_per_gpu}".split(" ")
     
     if dataset_name.find("MAG240") != -1:
-        additional_args = additional_args + "--train_fanouts 25 15 --test_fanouts 25 15 --valid_fanouts 25 15".split(" ")
+        additional_args = additional_args + "--train_fanouts 25 15 --test_fanouts 25 15 --valid_fanouts 25 15 --num_hidden 1024".split(" ")
 
     if pipeline_disabled:
         additional_args = additional_args + f"--pipeline_disabled {pipeline_disabled}".split(" ")


### PR DESCRIPTION
Setting NUM_MACHINES=1 in exp_driver.py so that users do not manually need to edit exp_driver.py num_devices_per_node when using the --local flag in helper scripts. Also fixed the num_hidden arg for mag240 in the helper function in exp_utils/utils.py 